### PR TITLE
Fix: Level Transitions, table borders, and drag and release, prevent console errors, remove unused link in html

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple Mini-golf game using HTML, CSS, JavaScript, and JQuery
 
 ## How to Play
 Simply go to the game's url to start playing.
-Drag forward and release anywhere on the screen to shoot, and try to get the ball in the hole in as few strokes as possible.
+Drag and release on the game area to shoot, and try to get the ball in the hole in as few strokes as possible.
 There are 7 holes to play through, with plenty of different mechanics to see.
 
 ## Hazards

--- a/css/index.css
+++ b/css/index.css
@@ -93,18 +93,20 @@ table {
     margin: auto;
     background-color: var(--sky);
     color: var(--navy);
-    border: none;
     border-collapse: collapse;
-    border: 5px solid var(--navy);
     border-radius: 5px;
     text-align: center;
     max-width: 500px;
     width: 85vw;
+    border: 5px solid var(--navy);
 }
 
-table, th, td {
-    border: 1px solid;
+th, td {
     min-width: 20px;
+}
+
+th, td {
+    border: 3px solid var(--navy);
 }
 
 /* Turn off animation if prefers reduces motion */
@@ -122,6 +124,7 @@ button {
     border-radius: 5px;
     margin: 10px;
     padding: 5px;
+    cursor: pointer;
 }
 button:active {
     background-color: var(--cyan);
@@ -130,6 +133,7 @@ button:disabled {
     background-color : gray;
     color: black;
     border: 5px solid gray;
+    cursor: not-allowed;
 }
 button:disabled:active {
     background-color : darkgray;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
         <link href="js/mini_golf.js">
         <link rel="stylesheet" href="css/index.css">
         <link rel="shortcut icon" href="assets/favicon.ico">
-        <link rel="stylesheet" media="screen" href="./assets/Cactron-Regular.otf" type="text/css"/>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
         <script type="module">
             import { startGame } from "./js/mini_golf.js";

--- a/js/data.js
+++ b/js/data.js
@@ -65,7 +65,7 @@ const level_1 = {
         ]}
     ],
     par : 2,
-    tip : "Get the ball in the hole in as few strokes as possible, drag and release to shoot"
+    tip : "Get the ball in the hole in as few strokes as possible, drag and release on the game area to shoot"
 }
 
 const level_2 = {


### PR DESCRIPTION
- If "Next level" is pressed in the middle of a level transition, the canvas turns black until it starts fading in again
- The table border was restored with a CSS fix
- Now you drag and release, not drag forward, more closely emulating real golf.
- prevent release mouse function from running if start or end position undefined to prevent error in browser console.
- prevent "cannot update undefined error" trying to update non-existent ball
- prevent trying to load font no longer present in project